### PR TITLE
Make `p2p.IOStats` goroutine-safe

### DIFF
--- a/circuit/evaluator.go
+++ b/circuit/evaluator.go
@@ -153,7 +153,7 @@ func Evaluator(conn *p2p.Conn, oti ot.OT, circ *Circuit, inputs *big.Int,
 	ioStats = conn.Stats
 	timing.Sample("Result", []string{FileSize(xfer.Sum()).String()})
 	if verbose {
-		timing.Print(conn.Stats.Sent, conn.Stats.Recvd)
+		timing.Print(conn.Stats.Sent.Load(), conn.Stats.Recvd.Load())
 	}
 
 	return circ.Outputs.Split(raw), nil

--- a/circuit/garbler.go
+++ b/circuit/garbler.go
@@ -177,7 +177,7 @@ func Garbler(conn *p2p.Conn, oti ot.OT, circ *Circuit, inputs *big.Int,
 	ioStats = conn.Stats
 	timing.Sample("Result", []string{FileSize(xfer.Sum()).String()})
 	if verbose {
-		timing.Print(conn.Stats.Sent, conn.Stats.Recvd)
+		timing.Print(conn.Stats.Sent.Load(), conn.Stats.Recvd.Load())
 	}
 
 	return circ.Outputs.Split(result), nil

--- a/circuit/player.go
+++ b/circuit/player.go
@@ -363,7 +363,7 @@ func Player(nw *p2p.Network, circ *Circuit, inputs *big.Int, verbose bool) (
 	ioStats = nw.Stats().Sub(ioStats)
 	timing.Sample("Result", []string{FileSize(ioStats.Sum()).String()})
 	if verbose {
-		timing.Print(nw.Stats().Sent, nw.Stats().Recvd)
+		timing.Print(nw.Stats().Sent.Load(), nw.Stats().Recvd.Load())
 	}
 
 	fmt.Printf("player not implemented yet\n")

--- a/circuit/stream_evaluator.go
+++ b/circuit/stream_evaluator.go
@@ -455,7 +455,7 @@ loop:
 	timing.Sample("Result", []string{FileSize(xfer.Sum()).String()})
 
 	if verbose {
-		timing.Print(conn.Stats.Sent, conn.Stats.Recvd)
+		timing.Print(conn.Stats.Sent.Load(), conn.Stats.Recvd.Load())
 	}
 
 	return outputs, outputs.Split(rawResult), nil

--- a/compiler/ssa/streamer.go
+++ b/compiler/ssa/streamer.go
@@ -542,7 +542,7 @@ func (prog *Program) StreamCircuit(conn *p2p.Conn, oti ot.OT,
 	timing.Sample("Result", []string{circuit.FileSize(xfer.Sum()).String()})
 
 	if params.Verbose {
-		timing.Print(conn.Stats.Sent, conn.Stats.Recvd)
+		timing.Print(conn.Stats.Sent.Load(), conn.Stats.Recvd.Load())
 	}
 
 	fmt.Printf("Max permanent wires: %d, cached circuits: %d\n",


### PR DESCRIPTION
Proposed solution for #11 

Behavior after this fix:
1. Shell 1:
    ```bash
    cd apps/garbled
    go run --race . -e -i 800000 examples/millionaire.mpcl
    ```
2. Shell 2:
    ```bash
    cd apps/garbled
    go run --race . -i 750000 examples/millionaire.mpcl
    ```
3. Output in Shell 1:
    ```
     - In1: a{1,0}i64:int64
     + In2: b{1,0}i64:int64
     - Out: %_{0,1}b1:bool1
     -  In: [800000]
    Listening for connections at :8080
    New connection from 127.0.0.1:61720
    Result[0]: false
    ```
5. Output in Shell 2:
    ```
     + In1: a{1,0}i64:int64
     - In2: b{1,0}i64:int64
     - Out: %_{0,1}b1:bool1
     -  In: [750000]
    Result[0]: false
    ```