### PR TITLE
Add bits package with add function

### DIFF
--- a/pkg/bits/bits.mpcl
+++ b/pkg/bits/bits.mpcl
@@ -1,0 +1,17 @@
+// -*- go -*-
+
+package bits
+
+// Add returns the sum with carry of x, y and carry: sum = x + y + carry.
+// The carry input must be 0 or 1; otherwise the behavior is undefined.
+// The carryOut output is guaranteed to be 0 or 1.
+//
+// This function's execution time does not depend on the inputs.
+func Add(x, y, carry uint) (sum, carryOut uint) {
+	sum = x + y + carry
+	// The sum will overflow if both top bits are set (x & y) or if one of them
+	// is (x | y), and a carry from the lower place happened. If such a carry
+	// happens, the top bit will be 1 + 0 + 1 = 0 (&^ sum).
+	carryOut = ((x & y) | ((x | y) &^ sum)) >> (size(carry)-1)
+	return
+}


### PR DESCRIPTION
This PR adds the `bits` package with an `Add` function. 
The function can check if the sum of two integers overflows or not. 
An example of this function's use is in a modular addition function, as shown below:

```go
func modAdd(x uint256, y uint256, mod uint256) uint256 {
	zero := uint256(0)
	sum, overflow := bits.Add(x, y, zero)
	if overflow != 0 || sum > mod {
		sum -= mod
	}

	return sum
}
```

Note that above example `modAdd` only works when `mod` is greater than 2^128 .